### PR TITLE
Remove timeout to keep focus synchronous with user interaction

### DIFF
--- a/src/core/SystemTextInputHandler.ts
+++ b/src/core/SystemTextInputHandler.ts
@@ -91,10 +91,7 @@ export class SystemTextInputHandler extends TextInputHandler {
     override askInput(currentText: string, selectStart: number, selectEnd: number): void {
         this.textInputElem.value = currentText;
         this.select(selectStart, selectEnd);
-        // HACK delay focus otherwise it doesn't work
-        setTimeout(() => {
-            this.textInputElem.focus({ preventScroll: true });
-        }, 10);
+        this.textInputElem.focus({ preventScroll: true });
     }
 
     override select(selectStart: number, selectEnd: number): void {


### PR DESCRIPTION
Remove timeout in askInput to keep focus synchronous with user interaction. 

On the latest iPhones the requirements are more strict about focussing elements from code. This causes the phones keyboard to not show when it is not immidiately followed on a user interaction.